### PR TITLE
57 make operations in dbt automation aware whether the input is a source or a model

### DIFF
--- a/dbt_automation/assets/operations.yaml.template
+++ b/dbt_automation/assets/operations.yaml.template
@@ -14,10 +14,16 @@ operations:
       config:
         output_name: <name of the output model>
         dest_schema: <enter your destination/output schema>
-        tablenames:
-            - <name of the 1st intermediate table>
-            - <name of the 2nd intermediate table>
-            - <name of the 3rd intermediate table>
+        input:
+            - input_type: <"source" or "model">
+              input_name: <name of source table or ref model>
+              source_name: <name of the source defined in source.yml; will be null for type "model">
+            - input_type: <"source" or "model">
+              input_name: <name of source table or ref model>
+              source_name: <name of the source defined in source.yml; will be null for type "model">
+            - input_type: <"source" or "model">
+              input_name: <name of source table or ref model>
+              source_name: <name of the source defined in source.yml; will be null for type "model">
     - type: syncsources
       config:
         source_name: <top level name of the source in sources.yml file in dbt project. all tables will go under here>

--- a/dbt_automation/assets/operations.yaml.template
+++ b/dbt_automation/assets/operations.yaml.template
@@ -24,11 +24,15 @@ operations:
         source_schema: <schema of the source mentioned above>
     - type: flattenjson
       config:
-        input_name: <name of the input model>
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema: <destination schema>
         output_name: <name of the output model>
         columns_to_copy:
-          - [columns to copy over from the source model]
+          - column1
+          - column2
         json_column: <name of the json column, strings are okay>
         json_columns_to_copy:
           - <json field 1>
@@ -36,16 +40,22 @@ operations:
 
     - type: castdatatypes
       config:
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema: <destination schema>
-        input_name: <name of the input model>
         output_name: <name of the output model>
         columns:
           - columnname: <column name>
             columntype: <type to cast column to>
     - type: coalescecolumns
       config: 
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema: <destination schema>
-        input_name: <name of the input model>
         output_name: <name of the output model>
         columns:
           - columnname: <first column>
@@ -54,8 +64,11 @@ operations:
         output_column_name: <output column name>
     - type: concat
       config: 
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema: <destination schema>
-        input_name: <name of the input model>
         output_name: <name of the output model>
         columns:
           - name: <string (column or const)>
@@ -68,8 +81,11 @@ operations:
 
     - type: arithmetic
       config:
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         output_name: <enter the name of the output model>
-        input_name: <enter your input model(tablename) on which you want to run the operation>
         dest_schema: <enter your destination/output schema>
         operator: <can be "add", "sub", "mul", "div">
         operands:
@@ -79,21 +95,30 @@ operations:
         output_column_name: <output column name>
     - type: dropcolumns
       config:
-        input_name: <name of the input model>
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema:  <destination schema>
         output_name: <name of the output model>
         columns:
           - <column name>
     - type: renamecolumns
       config: 
-        input_name: <name of the input model>
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema:  <destination schema>
         output_name: <name of the output model>
         columns:
           <old column name>: <new column name>
     - type: regexextraction
       config:
-        input_name: <name of the input model>
+        input: 
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         dest_schema:  <destination schema>
         output_name: <name of the output model>
         columns:

--- a/dbt_automation/operations/arithmetic.py
+++ b/dbt_automation/operations/arithmetic.py
@@ -5,7 +5,7 @@ This file contains the airthmetic operations for dbt automation
 from logging import basicConfig, getLogger, INFO
 from dbt_automation.utils.dbtproject import dbtProject
 from dbt_automation.utils.interfaces.warehouse_interface import WarehouseInterface
-
+from dbt_automation.utils.tableutils import source_or_ref
 
 basicConfig(level=INFO)
 logger = getLogger()
@@ -13,9 +13,11 @@ logger = getLogger()
 
 # pylint:disable=unused-argument,logging-fstring-interpolation
 def arithmetic(config: dict, warehouse: WarehouseInterface, project_dir: str):
-    """performs arithmetic operations: +/-/*//"""
+    """
+    performs arithmetic operations: +/-/*//
+    config["input"] is dict {"source_name": "", "input_name": "", "input_type": ""}
+    """
     output_name = config["output_name"]
-    input_model = config["input_name"]
     dest_schema = config["dest_schema"]
     operator = config["operator"]
     operands = config["operands"]
@@ -69,7 +71,7 @@ def arithmetic(config: dict, warehouse: WarehouseInterface, project_dir: str):
         dbt_code += ")}}"
         dbt_code += f" AS {output_col_name} "
 
-    dbt_code += " FROM " + "{{ref('" + input_model + "')}}" + "\n"
+    dbt_code += " FROM " + "{{" + source_or_ref(**config["input"]) + "}}" + "\n"
 
     logger.info(f"writing dbt model {dbt_code}")
     model_sql_path = dbtproject.write_model(dest_schema, output_name, dbt_code)

--- a/dbt_automation/operations/coalescecolumns.py
+++ b/dbt_automation/operations/coalescecolumns.py
@@ -5,7 +5,7 @@ from logging import basicConfig, getLogger, INFO
 from dbt_automation.utils.dbtproject import dbtProject
 from dbt_automation.utils.columnutils import quote_columnname
 from dbt_automation.utils.interfaces.warehouse_interface import WarehouseInterface
-
+from dbt_automation.utils.tableutils import source_or_ref
 
 basicConfig(level=INFO)
 logger = getLogger()
@@ -13,10 +13,11 @@ logger = getLogger()
 
 # pylint:disable=unused-argument,logging-fstring-interpolation
 def coalesce_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
-    """coalesces columns"""
+    """
+    coalesces columns
+    """
     dest_schema = config["dest_schema"]
     output_name = config["output_name"]
-    input_name = config["input_name"]
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(dest_schema)
@@ -25,7 +26,11 @@ def coalesce_columns(config: dict, warehouse: WarehouseInterface, project_dir: s
 
     columns = config["columns"]
     columnnames = [c["columnname"] for c in columns]
-    union_code += "SELECT {{dbt_utils.star(from=ref('" + input_name + "'), except=["
+    union_code += (
+        "SELECT {{dbt_utils.star(from="
+        + source_or_ref(**config["input"])
+        + ", except=["
+    )
     union_code += ",".join([f'"{columnname}"' for columnname in columnnames])
     union_code += "])}}"
 
@@ -35,7 +40,7 @@ def coalesce_columns(config: dict, warehouse: WarehouseInterface, project_dir: s
         union_code += quote_columnname(column["columnname"], warehouse.name) + ", "
     union_code = union_code[:-2] + ") AS " + config["output_column_name"]
 
-    union_code += " FROM " + "{{ref('" + input_name + "')}}" + "\n"
+    union_code += " FROM " + "{{" + source_or_ref(**config["input"]) + "}}" + "\n"
 
     logger.info(f"writing dbt model {union_code}")
     model_sql_path = dbtproject.write_model(

--- a/dbt_automation/operations/concatcolumns.py
+++ b/dbt_automation/operations/concatcolumns.py
@@ -6,19 +6,19 @@ from logging import basicConfig, getLogger, INFO
 from dbt_automation.utils.dbtproject import dbtProject
 from dbt_automation.utils.columnutils import quote_columnname
 from dbt_automation.utils.interfaces.warehouse_interface import WarehouseInterface
-
+from dbt_automation.utils.tableutils import source_or_ref
 
 basicConfig(level=INFO)
 logger = getLogger()
 
 
 def concat_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
-    """This function generates dbt model to concat strings"""
+    """
+    This function generates dbt model to concat strings
+    """
     logger.info("here in concat columns")
-    logger.info("testing")
     dest_schema = config["dest_schema"]
     output_name = config["output_name"]
-    input_name = config["input_name"]
     output_column_name = config["output_column_name"]
     columns = config["columns"]
 
@@ -37,7 +37,7 @@ def concat_columns(config: dict, warehouse: WarehouseInterface, project_dir: str
         ]
     )
     dbt_code += f"SELECT *, CONCAT({concat_fields}) AS {output_column_name}"
-    dbt_code += " FROM " + "{{ref('" + input_name + "')}}" + "\n"
+    dbt_code += " FROM " + "{{" + source_or_ref(**config["input"]) + "}}" + "\n"
 
     model_sql_path = dbtproject.write_model(dest_schema, output_name, dbt_code)
     return model_sql_path

--- a/dbt_automation/operations/droprenamecolumns.py
+++ b/dbt_automation/operations/droprenamecolumns.py
@@ -36,7 +36,7 @@ def drop_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
 
 def rename_columns(config: dict, warehouse, project_dir: str):
     """renames columns in a model"""
-    input_name = config["input_name"]
+    # input_name = config["input_name"]
     dest_schema = config["dest_schema"]
     columns = config.get("columns", {})
     output_model_name = config["output_name"]
@@ -45,15 +45,19 @@ def rename_columns(config: dict, warehouse, project_dir: str):
     dbtproject.ensure_models_dir(dest_schema)
 
     model_code = '{{ config(materialized="table", schema="' + dest_schema + '") }}\n\n'
-    exclude_cols = ",".join([f'"{col}"' for col in columns.keys()])
-    model_code += f'SELECT {{{{ dbt_utils.star(from=ref("{input_name}"), except=[{exclude_cols}]) }}}}, '
+    model_code += (
+        "SELECT {{dbt_utils.star(from="
+        + source_or_ref(**config["input"])
+        + ", except=["
+    )
+    model_code += ",".join([f'"{col}"' for col in columns.keys()])
+    model_code += "])}} , "
 
     for old_name, new_name in columns.items():
-        model_code += f"""{quote_columnname(old_name, warehouse.name)}
-                    AS {quote_columnname(new_name, warehouse.name)}, """
+        model_code += f"""{quote_columnname(old_name, warehouse.name)} AS {quote_columnname(new_name, warehouse.name)}, """
 
     model_code = model_code[:-2]  # Remove trailing comma and space
-    model_code += f'\nFROM \n  {{{{ ref("{input_name}") }}}}'
+    model_code += " FROM " + "{{" + source_or_ref(**config["input"]) + "}}" + "\n"
 
     model_sql_path = dbtproject.write_model(dest_schema, output_model_name, model_code)
     return model_sql_path

--- a/dbt_automation/operations/droprenamecolumns.py
+++ b/dbt_automation/operations/droprenamecolumns.py
@@ -5,7 +5,7 @@ from logging import basicConfig, getLogger, INFO
 from dbt_automation.utils.dbtproject import dbtProject
 from dbt_automation.utils.columnutils import quote_columnname
 from dbt_automation.utils.interfaces.warehouse_interface import WarehouseInterface
-
+from dbt_automation.utils.tableutils import source_or_ref
 
 basicConfig(level=INFO)
 logger = getLogger()
@@ -15,13 +15,18 @@ logger = getLogger()
 def drop_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """drops columns from a model"""
     dest_schema = config["dest_schema"]
-    input_name = config["input_name"]
     columns = config.get("columns", [])
     output_model_name = config["output_name"]
 
     model_code = f'{{{{ config(materialized="table", schema="{dest_schema}") }}}}\n'
-    columns = ",".join([f'"{col}"' for col in columns])
-    model_code += f'SELECT {{{{ dbt_utils.star(from=ref("{input_name}"), except=[{columns}]) }}}} FROM {{{{ref("{input_name}")}}}}\n'
+    model_code += (
+        "SELECT {{dbt_utils.star(from="
+        + source_or_ref(**config["input"])
+        + ", except=["
+    )
+    model_code += ",".join([f'"{col}"' for col in columns])
+    model_code += "])}}"
+    model_code += " FROM " + "{{" + source_or_ref(**config["input"]) + "}}" + "\n"
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(dest_schema)

--- a/dbt_automation/operations/droprenamecolumns.py
+++ b/dbt_automation/operations/droprenamecolumns.py
@@ -36,7 +36,6 @@ def drop_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
 
 def rename_columns(config: dict, warehouse, project_dir: str):
     """renames columns in a model"""
-    # input_name = config["input_name"]
     dest_schema = config["dest_schema"]
     columns = config.get("columns", {})
     output_model_name = config["output_name"]

--- a/dbt_automation/operations/flattenjson.py
+++ b/dbt_automation/operations/flattenjson.py
@@ -6,7 +6,7 @@ from dbt_automation.utils.dbtproject import dbtProject
 from dbt_automation.utils.columnutils import quote_columnname
 from dbt_automation.utils.columnutils import make_cleaned_column_names, dedup_list
 from dbt_automation.utils.interfaces.warehouse_interface import WarehouseInterface
-
+from dbt_automation.utils.tableutils import source_or_ref
 
 basicConfig(level=INFO)
 logger = getLogger()
@@ -16,7 +16,7 @@ logger = getLogger()
 def flattenjson(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """
     source_schema: name of the input schema
-    input_name: name of the input model
+    input: input dictionary check operations.yaml.template
     dest_schema: name of the output schema
     output_name: name of the output model
     columns_to_copy: list of columns to copy from the input model
@@ -24,7 +24,6 @@ def flattenjson(config: dict, warehouse: WarehouseInterface, project_dir: str):
     json_columns_to_copy: list of columns to copy from the json_column
     """
 
-    input_name = config["input_name"]
     dest_schema = config["dest_schema"]
     output_name = config["output_name"]
     columns_to_copy = config["columns_to_copy"]
@@ -51,7 +50,7 @@ def flattenjson(config: dict, warehouse: WarehouseInterface, project_dir: str):
             "," + warehouse.json_extract_op(json_column, json_field, sql_column) + "\n"
         )
 
-    model_code += " FROM " + "{{ref('" + input_name + "')}}" + "\n"
+    model_code += " FROM " + "{{" + source_or_ref(**config["input"]) + "}}" + "\n"
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(dest_schema)

--- a/dbt_automation/utils/tableutils.py
+++ b/dbt_automation/utils/tableutils.py
@@ -1,0 +1,15 @@
+"""
+This file will take all helpers need to work with dbt sources and dbt models
+"""
+
+
+def source_or_ref(source_name: str, input_name: str, input_type: str) -> str:
+    if input_type not in ["source", "model"]:
+        raise ValueError("invalid input type to select from")
+
+    source_or_ref = f"ref('{input_name}')"
+
+    if input_type == "source":
+        source_or_ref = f"source('{source_name}', '{input_name}')"
+
+    return source_or_ref

--- a/tests/utils/test_tableutils.py
+++ b/tests/utils/test_tableutils.py
@@ -1,0 +1,39 @@
+import pytest
+from dbt_automation.utils.tableutils import source_or_ref
+
+
+@pytest.fixture
+def source():
+    return {
+        "input_type": "source",
+        "input_name": "src_table",
+        "source_name": "src_name",
+    }
+
+
+@pytest.fixture
+def model_ref():
+    return {
+        "input_type": "model",
+        "input_name": "src_table",
+        "source_name": "src_name",
+    }
+
+
+def test_correct_source(source):
+    assert "input_type" in source
+    assert "input_name" in source
+    assert "source_name" in source
+    assert source["input_type"] == "source"
+    src_name = source["source_name"]
+    inp_name = source["input_name"]
+    assert source_or_ref(**source) == f"source('{src_name}', '{inp_name}')"
+
+
+def test_correct_model(model_ref):
+    assert "input_type" in model_ref
+    assert "input_name" in model_ref
+    assert "source_name" in model_ref
+    assert model_ref["input_type"] == "model"
+    inp_name = model_ref["input_name"]
+    assert source_or_ref(**model_ref) == f"ref('{inp_name}')"

--- a/tests/warehouse/test_bigquery_ops.py
+++ b/tests/warehouse/test_bigquery_ops.py
@@ -125,7 +125,11 @@ class TestBigqueryOperations:
         wc_client = TestBigqueryOperations.wc_client
         output_name = "rename"
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": {"NGO": "ngo", "Month": "month"},
@@ -151,7 +155,11 @@ class TestBigqueryOperations:
         output_name = "drop"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": ["MONTH"],
@@ -174,7 +182,11 @@ class TestBigqueryOperations:
         output_name = "coalesce"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
@@ -215,7 +227,11 @@ class TestBigqueryOperations:
         output_name = "concat"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
@@ -257,7 +273,11 @@ class TestBigqueryOperations:
         output_name = "cast"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
@@ -294,7 +314,11 @@ class TestBigqueryOperations:
         output_name = "arithmetic_add"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "add",
@@ -324,7 +348,11 @@ class TestBigqueryOperations:
         output_name = "arithmetic_sub"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "sub",
@@ -354,7 +382,11 @@ class TestBigqueryOperations:
         output_name = "arithmetic_mul"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "mul",
@@ -384,7 +416,11 @@ class TestBigqueryOperations:
         output_name = "arithmetic_div"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "div",
@@ -419,7 +455,11 @@ class TestBigqueryOperations:
         output_name = "regex_ext"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": {"NGO": "^[C].*"},
@@ -456,7 +496,18 @@ class TestBigqueryOperations:
         config = {
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
-            "tablenames": ["Sheet1", "Sheet2"],
+            "input_arr": [
+                {
+                    "input_type": "model",
+                    "input_name": "Sheet1",
+                    "source_name": None,
+                },
+                {
+                    "input_type": "model",
+                    "input_name": "Sheet2",
+                    "source_name": None,
+                },
+            ],
         }
 
         union_tables(

--- a/tests/warehouse/test_postgres_ops.py
+++ b/tests/warehouse/test_postgres_ops.py
@@ -129,7 +129,11 @@ class TestPostgresOperations:
         wc_client = TestPostgresOperations.wc_client
         output_name = "rename"
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": {"NGO": "ngo", "Month": "month"},
@@ -155,7 +159,11 @@ class TestPostgresOperations:
         output_name = "drop"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": ["MONTH"],
@@ -178,7 +186,11 @@ class TestPostgresOperations:
         output_name = "coalesce"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
@@ -218,7 +230,11 @@ class TestPostgresOperations:
         output_name = "concat"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
@@ -260,7 +276,11 @@ class TestPostgresOperations:
         output_name = "cast"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
@@ -297,7 +317,11 @@ class TestPostgresOperations:
         output_name = "arithmetic_add"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "add",
@@ -327,7 +351,11 @@ class TestPostgresOperations:
         output_name = "arithmetic_sub"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "sub",
@@ -357,7 +385,11 @@ class TestPostgresOperations:
         output_name = "arithmetic_mul"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "mul",
@@ -387,7 +419,11 @@ class TestPostgresOperations:
         output_name = "arithmetic_div"
 
         config = {
-            "input_name": "cast",  # from previous operation
+            "input": {
+                "input_type": "model",
+                "input_name": "cast",
+                "source_name": None,
+            },  # from previous operation
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "operator": "div",
@@ -423,7 +459,11 @@ class TestPostgresOperations:
         output_name = "regex_ext"
 
         config = {
-            "input_name": "Sheet1",
+            "input": {
+                "input_type": "model",
+                "input_name": "Sheet1",
+                "source_name": None,
+            },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": {"NGO": "^[C].*"},
@@ -462,7 +502,18 @@ class TestPostgresOperations:
         config = {
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
-            "tablenames": ["Sheet1", "Sheet2"],
+            "input_arr": [
+                {
+                    "input_type": "model",
+                    "input_name": "Sheet1",
+                    "source_name": None,
+                },
+                {
+                    "input_type": "model",
+                    "input_name": "Sheet2",
+                    "source_name": None,
+                },
+            ],
         }
 
         union_tables(


### PR DESCRIPTION
- tested all operations by running our script with yaml as input config
- tested all operations by passing a source and a mode
- skipped `flattenairbyte` since it is supposed to be run on source and not model
- no changes to `syncsources` and `scaffold`
- moved operations.yaml.template inside the package in assets folder. update it with the new `input` config
- created a helper function for source or ref