### PR TITLE
ui4t updates

### DIFF
--- a/dbt_automation/assets/operations.template.yml
+++ b/dbt_automation/assets/operations.template.yml
@@ -79,8 +79,8 @@ operations:
           - <column name>
           - ...
         columns:
-          - columnname: <first column>
-          - columnname: <second column>
+          - <first column>
+          - <second column>
           - ...
         output_column_name: <output column name>
     - type: concat
@@ -98,11 +98,11 @@ operations:
           - ...
         columns:
           - name: <string (column or const)>
-            is_col: <yes or no>
+            is_col: <boolean>
           - name: <string (column or const)>
-            is_col: <yes or no>
+            is_col: <boolean>
           - name: <string (column or const)>
-            is_col: <yes or no>
+            is_col: <boolean>
         output_column_name: <output column name>
 
     - type: arithmetic
@@ -211,8 +211,8 @@ operations:
                 - <column name>
                 - ...
               columns:
-                - columnname: <column_name>
-                - columnname: <column_name>
+                - <column_name>
+                - <column_name>
               output_column_name: <output_column_name>
           - type: concat
             config:
@@ -223,11 +223,11 @@ operations:
                 - ...
               columns:
                 - name: <column_name>
-                  is_col: <yes_or_no>
+                  is_col: <boolean>
                 - name: <column_name>
-                  is_col: <yes_or_no>
+                  is_col: <boolean>
                 - name: <column_name>
-                  is_col: <yes_or_no>
+                  is_col: <boolean>
               output_column_name: <output_column_name>
           - type: dropcolumns
             config:

--- a/dbt_automation/assets/operations.template.yml
+++ b/dbt_automation/assets/operations.template.yml
@@ -175,16 +175,13 @@ operations:
       config:
         dest_schema: <destination_schema>
         output_name: mergeoperation
-        source_name: <name of the source defined in source.yml; will be null for type "model">
+        input:
+          input_type: <"source" or "model">
+          input_name: <name of source table or ref model>
+          source_name: <name of the source defined in source.yml; will be null for type "model">
         operations:
           - type: castdatatypes
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: cast_output
               source_columns:
                 - <column name>
                 - <column name>
@@ -195,12 +192,6 @@ operations:
                   columntype: <column_type>
           - type: arithmetic
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              output_name: arithmetic_output
-              dest_schema: <intermediate_schema>
               operator: <operator>
               source_columns:
                 - <column name>
@@ -214,12 +205,6 @@ operations:
               output_column_name: <output_column_name>
           - type: coalescecolumns
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: coalesce_columns
               source_columns:
                 - <column name>
                 - <column name>
@@ -231,12 +216,6 @@ operations:
               output_column_name: <output_column_name>
           - type: concat
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: concat
               source_columns:
                 - <column name>
                 - <column name>
@@ -252,27 +231,14 @@ operations:
               output_column_name: <output_column_name>
           - type: dropcolumns
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: drop_column
               source_columns:
                 - <column name>
                 - <column name>
                 - <column name>
-          - ...
               columns:
                 - <column_name>
           - type: renamecolumns
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: rename_column
               source_columns:
                 - <column name>
                 - <column name>
@@ -282,12 +248,6 @@ operations:
                 <old_column_name>: <new_column_name>
           - type: flattenjson
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: flatten_json
               source_columns:
                 - <column name>
                 - <column name>
@@ -302,17 +262,10 @@ operations:
                 - <json_column_name>
           - type: regexextraction
             config:
-              input:
-                input_type: <source_type>
-                input_name: <source_name>
-                source_name: <source_name>
-              dest_schema: <intermediate_schema>
-              output_name: regex_extraction
               source_columns:
                 - <column name>
                 - <column name>
                 - <column name>
-                - ...
               columns:
                 <column_name>: <regex_pattern>
                 <column_name>: <regex_pattern>

--- a/dbt_automation/assets/operations.template.yml
+++ b/dbt_automation/assets/operations.template.yml
@@ -24,6 +24,11 @@ operations:
             - input_type: <"source" or "model">
               input_name: <name of source table or ref model>
               source_name: <name of the source defined in source.yml; will be null for type "model">
+        source_columns:
+          - <column name>
+          - <column name>
+          - <column name>
+          - ...
     - type: syncsources
       config:
         source_name: <top level name of the source in sources.yml file in dbt project. all tables will go under here>

--- a/dbt_automation/operations/castdatatypes.py
+++ b/dbt_automation/operations/castdatatypes.py
@@ -22,7 +22,7 @@ WAREHOUSE_COLUMN_TYPES = {
 def cast_datatypes_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """
     Generate SQL code for the cast_datatypes operation.
     """
@@ -57,9 +57,7 @@ def cast_datatypes_sql(
     return dbt_code, source_columns
 
 
-def cast_datatypes(
-    config: dict, warehouse: WarehouseInterface, project_dir: str
-) -> str:
+def cast_datatypes(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """
     Perform casting of data types and generate a DBT model.
     """

--- a/dbt_automation/operations/coalescecolumns.py
+++ b/dbt_automation/operations/coalescecolumns.py
@@ -15,7 +15,7 @@ logger = getLogger()
 def coalesce_columns_dbt_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """
     Generate SQL code for the coalesce_columns operation.
     """

--- a/dbt_automation/operations/concatcolumns.py
+++ b/dbt_automation/operations/concatcolumns.py
@@ -15,7 +15,7 @@ logger = getLogger()
 def concat_columns_dbt_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """
     Generate SQL code for the concat_columns operation.
     """
@@ -48,9 +48,7 @@ def concat_columns_dbt_sql(
     return dbt_code, source_columns + [output_column_name]
 
 
-def concat_columns(
-    config: dict, warehouse: WarehouseInterface, project_dir: str
-) -> str:
+def concat_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """
     Perform concatenation of columns and generate a DBT model.
     """

--- a/dbt_automation/operations/concatcolumns.py
+++ b/dbt_automation/operations/concatcolumns.py
@@ -20,19 +20,22 @@ def concat_columns_dbt_sql(
     Generate SQL code for the concat_columns operation.
     """
     output_column_name = config["output_column_name"]
-    columns = config["columns"]
+    concat_columns = config["columns"]
     source_columns = config["source_columns"]
-
-    columns_to_concat = [
-        col["name"] for col in columns if col.get("is_col", "yes") == "yes"
-    ]
-
-    concat_fields = ",".join(
-        [quote_columnname(col, warehouse.name) for col in columns_to_concat]
-    )
 
     dbt_code = "SELECT " + ", ".join(
         [quote_columnname(col, warehouse.name) for col in source_columns]
+    )
+
+    concat_fields = ",".join(
+        [
+            (
+                quote_columnname(col["name"], warehouse.name)
+                if col["is_col"]
+                else f"'{col['name']}'"
+            )
+            for col in concat_columns
+        ]
     )
     dbt_code += f", CONCAT({concat_fields}) AS {quote_columnname(output_column_name, warehouse.name)}"
 
@@ -42,7 +45,7 @@ def concat_columns_dbt_sql(
     else:
         dbt_code += f"\nFROM {{{{ {select_from} }}}}\n"
 
-    return dbt_code
+    return dbt_code, source_columns + [output_column_name]
 
 
 def concat_columns(
@@ -51,19 +54,20 @@ def concat_columns(
     """
     Perform concatenation of columns and generate a DBT model.
     """
-    config_sql = ""
+    dbt_sql = ""
     if config["input"]["input_type"] != "cte":
-        config_sql = (
+        dbt_sql = (
             "{{ config(materialized='table', schema='" + config["dest_schema"] + "') }}"
         )
 
-    sql = config_sql + "\n" + concat_columns_dbt_sql(config, warehouse)
+    select_statement, output_cols = concat_columns_dbt_sql(config, warehouse)
+    dbt_sql += "\n" + select_statement
 
     dbt_project = dbtProject(project_dir)
     dbt_project.ensure_models_dir(config["dest_schema"])
 
     model_sql_path = dbt_project.write_model(
-        config["dest_schema"], config["output_name"], sql
+        config["dest_schema"], config["output_name"], dbt_sql
     )
 
-    return model_sql_path
+    return model_sql_path, output_cols

--- a/dbt_automation/operations/droprenamecolumns.py
+++ b/dbt_automation/operations/droprenamecolumns.py
@@ -15,7 +15,7 @@ logger = getLogger()
 def drop_columns_dbt_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """
     Generate SQL code for dropping columns from the source.
     """
@@ -63,7 +63,7 @@ def drop_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
 def rename_columns_dbt_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """Generate SQL code for renaming columns in a model."""
     columns = config.get("columns", {})
     source_columns = config["source_columns"]

--- a/dbt_automation/operations/droprenamecolumns.py
+++ b/dbt_automation/operations/droprenamecolumns.py
@@ -22,10 +22,10 @@ def drop_columns_dbt_sql(
     columns = config.get("columns", [])
     source_columns = config["source_columns"]
 
-    columns_to_drop = [col for col in source_columns if col not in columns]
+    remaining_cols = [col for col in source_columns if col not in columns]
 
     dbt_code = "SELECT " + ", ".join(
-        [quote_columnname(col, warehouse.name) for col in columns_to_drop]
+        [quote_columnname(col, warehouse.name) for col in remaining_cols]
     )
 
     select_from = source_or_ref(**config["input"])
@@ -34,29 +34,30 @@ def drop_columns_dbt_sql(
     else:
         dbt_code += f"\nFROM {{{{ {select_from} }}}}\n"
 
-    return dbt_code
+    return dbt_code, remaining_cols
 
 
-def drop_columns(config: dict, warehouse: WarehouseInterface, project_dir: str) -> str:
+def drop_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """
     Perform dropping of columns and generate a DBT model.
     """
-    config_sql = ""
+    dbt_sql = ""
     if config["input"]["input_type"] != "cte":
-        config_sql = (
+        dbt_sql = (
             "{{ config(materialized='table', schema='" + config["dest_schema"] + "') }}"
         )
 
-    sql = config_sql + "\n" + drop_columns_dbt_sql(config, warehouse)
+    select_statement, output_cols = drop_columns_dbt_sql(config, warehouse)
+    dbt_sql += "\n" + select_statement
 
     dbt_project = dbtProject(project_dir)
     dbt_project.ensure_models_dir(config["dest_schema"])
 
     output_model_name = config["output_name"]
     dest_schema = config["dest_schema"]
-    model_sql_path = dbt_project.write_model(dest_schema, output_model_name, sql)
+    model_sql_path = dbt_project.write_model(dest_schema, output_model_name, dbt_sql)
 
-    return model_sql_path
+    return model_sql_path, output_cols
 
 
 def rename_columns_dbt_sql(
@@ -86,25 +87,24 @@ def rename_columns_dbt_sql(
     else:
         dbt_code += "\n FROM " + "{{" + select_from + "}}" + "\n"
 
-    return dbt_code
+    return dbt_code, selected_columns + list(columns.values())
 
 
-def rename_columns(
-    config: dict, warehouse: WarehouseInterface, project_dir: str
-) -> str:
+def rename_columns(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """Perform renaming of columns and generate a DBT model."""
     dest_schema = config["dest_schema"]
     output_model_name = config["output_name"]
-    config_sql = ""
+    dbt_sql = ""
     if config["input"]["input_type"] != "cte":
-        config_sql = (
+        dbt_sql = (
             "{{ config(materialized='table', schema='" + config["dest_schema"] + "') }}"
         )
 
-    sql = config_sql + "\n" + rename_columns_dbt_sql(config, warehouse)
+    select_statement, output_cols = rename_columns_dbt_sql(config, warehouse)
+    dbt_sql += "\n" + select_statement
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(dest_schema)
-    model_sql_path = dbtproject.write_model(dest_schema, output_model_name, sql)
+    model_sql_path = dbtproject.write_model(dest_schema, output_model_name, dbt_sql)
 
-    return model_sql_path
+    return model_sql_path, output_cols

--- a/dbt_automation/operations/flattenjson.py
+++ b/dbt_automation/operations/flattenjson.py
@@ -16,7 +16,7 @@ logger = getLogger()
 def flattenjson_dbt_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """
     source_schema: name of the input schema
     input: input dictionary check operations.yaml.template

--- a/dbt_automation/operations/flattenjson.py
+++ b/dbt_automation/operations/flattenjson.py
@@ -54,7 +54,7 @@ def flattenjson_dbt_sql(
     else:
         dbt_code += "\n FROM " + "{{" + select_from + "}}" + "\n"
 
-    return dbt_code
+    return dbt_code, source_columns + sql_columns
 
 
 def flattenjson(config: dict, warehouse: WarehouseInterface, project_dir: str):
@@ -62,19 +62,20 @@ def flattenjson(config: dict, warehouse: WarehouseInterface, project_dir: str):
     Flatten JSON columns.
     """
 
-    config_sql = ""
+    dbt_sql = ""
     if config["input"]["input_type"] != "cte":
-        config_sql = (
+        dbt_sql = (
             "{{ config(materialized='table', schema='" + config["dest_schema"] + "') }}"
         )
 
-    sql_code = config_sql + "\n" + flattenjson_dbt_sql(config, warehouse)
+    select_statement, output_cols = flattenjson_dbt_sql(config, warehouse)
+    dbt_sql += "\n" + select_statement
 
     dest_schema = config["dest_schema"]
     output_name = config["output_name"]
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(dest_schema)
-    model_sql_path = dbtproject.write_model(dest_schema, output_name, sql_code)
+    model_sql_path = dbtproject.write_model(dest_schema, output_name, dbt_sql)
 
-    return model_sql_path
+    return model_sql_path, output_cols

--- a/dbt_automation/operations/mergeoperations.py
+++ b/dbt_automation/operations/mergeoperations.py
@@ -71,7 +71,7 @@ def merge_operations_sql(
 
 
 def merge_operations(
-    config: List[dict],
+    config: dict,
     warehouse: WarehouseInterface,
     project_dir: str,
 ) -> str:

--- a/dbt_automation/operations/mergeoperations.py
+++ b/dbt_automation/operations/mergeoperations.py
@@ -100,6 +100,7 @@ def merge_operations(
         "{{ config(materialized='table', schema='" + config["dest_schema"] + "') }}\n"
     )
 
+    # TODO: input can be model or a source; needs a dict
     sql = config_sql + merge_operations_sql(
         config["operations"],
         warehouse,

--- a/dbt_automation/operations/mergetables.py
+++ b/dbt_automation/operations/mergetables.py
@@ -42,10 +42,9 @@ def union_tables_sql(config, warehouse: WarehouseInterface):
 
     include_cols = [f'"{col}"' for col in source_columns]
 
-
     # pylint:disable=consider-using-f-string
     dbt_code += "{{ dbt_utils.union_relations("
-    dbt_code += f"relations={relations} , include=[{",".join(include_cols)}]" 
+    dbt_code += f"relations={relations} , " + f"include=[{','.join(include_cols)}]"
     dbt_code += ")}}"
 
     return dbt_code, source_columns

--- a/dbt_automation/operations/mergetables.py
+++ b/dbt_automation/operations/mergetables.py
@@ -20,6 +20,7 @@ def union_tables_sql(config, warehouse: WarehouseInterface):
     """Generates SQL code for unioning tables using the dbt_utils union_relations macro."""
     input_arr = config["input_arr"]
     dest_schema = config["dest_schema"]
+    source_columns = config["source_columns"]
 
     names = set()
     for input in input_arr:
@@ -39,19 +40,22 @@ def union_tables_sql(config, warehouse: WarehouseInterface):
     if config["input_arr"][0]["input_type"] != "cte":
         dbt_code += f"{{{{ config(materialized='table',schema='{dest_schema}') }}}}\n"
 
+    include_cols = [f'"{col}"' for col in source_columns]
+
+
     # pylint:disable=consider-using-f-string
     dbt_code += "{{ dbt_utils.union_relations("
-    dbt_code += f"relations={relations}"
+    dbt_code += f"relations={relations} , include=[{",".join(include_cols)}]" 
     dbt_code += ")}}"
 
-    return dbt_code
+    return dbt_code, source_columns
 
 
 def union_tables(config, warehouse: WarehouseInterface, project_dir):
     """Generates a dbt model which uses the dbt_utils union_relations macro to union tables."""
     output_model_name = config["output_name"]
 
-    union_code = union_tables_sql(config, warehouse)
+    union_code, output_cols = union_tables_sql(config, warehouse)
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(config["dest_schema"])
@@ -62,7 +66,7 @@ def union_tables(config, warehouse: WarehouseInterface, project_dir):
         union_code,
     )
 
-    return model_sql_path
+    return model_sql_path, output_cols
 
 
 if __name__ == "__main__":

--- a/dbt_automation/operations/regexextraction.py
+++ b/dbt_automation/operations/regexextraction.py
@@ -18,17 +18,15 @@ def regex_extraction_sql(
 
     select_expressions = []
 
-    for col_name in source_columns:
-        if col_name in columns:
-            regex = columns[col_name]
-            if warehouse.name == "postgres":
-                select_expressions.append(
-                    f"substring({quote_columnname(col_name, warehouse.name)} FROM '{regex}') AS {quote_columnname(col_name, warehouse.name)}"
-                )
-            elif warehouse.name == "bigquery":
-                select_expressions.append(
-                    f"REGEXP_EXTRACT({quote_columnname(col_name, warehouse.name)}, r'{regex}') AS {quote_columnname(col_name, warehouse.name)}"
-                )
+    for col_name, regex in columns.items():
+        if warehouse.name == "postgres":
+            select_expressions.append(
+                f"substring({quote_columnname(col_name, warehouse.name)} FROM '{regex}') AS {quote_columnname(col_name, warehouse.name)}"
+            )
+        elif warehouse.name == "bigquery":
+            select_expressions.append(
+                f"REGEXP_EXTRACT({quote_columnname(col_name, warehouse.name)}, r'{regex}') AS {quote_columnname(col_name, warehouse.name)}"
+            )
 
     dbt_code += ", ".join(select_expressions)
 
@@ -45,29 +43,27 @@ def regex_extraction_sql(
     else:
         dbt_code += "\n FROM " + "{{" + select_from + "}}" + "\n"
 
-    return dbt_code
+    return dbt_code, non_regex_columns + list(columns.keys())
 
 
 def regex_extraction(config: dict, warehouse: WarehouseInterface, project_dir: str):
     """
     Generate DBT model file for regex extraction.
     """
-    config_sql = ""
+    dest_schema = config["dest_schema"]
+    output_model_name = config["output_name"]
+    dbt_sql = ""
     if config["input"]["input_type"] != "cte":
-        config_sql = (
+        dbt_sql = (
             "{{ config(materialized='table', schema='" + config["dest_schema"] + "') }}"
         )
 
-    output_model_sql = config_sql + "\n" + regex_extraction_sql(config, warehouse)
-
-    dest_schema = config["dest_schema"]
-    output_model_name = config["output_name"]
+    select_statement, output_cols = regex_extraction_sql(config, warehouse)
+    dbt_sql += "\n" + select_statement
 
     dbtproject = dbtProject(project_dir)
     dbtproject.ensure_models_dir(dest_schema)
 
-    model_sql_path = dbtproject.write_model(
-        dest_schema, output_model_name, output_model_sql
-    )
+    model_sql_path = dbtproject.write_model(dest_schema, output_model_name, dbt_sql)
 
-    return model_sql_path
+    return model_sql_path, output_cols

--- a/dbt_automation/operations/regexextraction.py
+++ b/dbt_automation/operations/regexextraction.py
@@ -9,7 +9,7 @@ from dbt_automation.utils.tableutils import source_or_ref
 def regex_extraction_sql(
     config: dict,
     warehouse: WarehouseInterface,
-) -> str:
+):
     """Given a regex and a column name, extract the regex from the column."""
     columns = config.get("columns", {})
     source_columns = config["source_columns"]

--- a/dbt_automation/utils/bigquery.py
+++ b/dbt_automation/utils/bigquery.py
@@ -45,11 +45,14 @@ class BigQueryClient(WarehouseInterface):
         return [x.dataset_id for x in datasets]
 
     def get_table_columns(self, schema: str, table: str) -> list:
-        """fetch the list of columns from a BigQuery table."""
+        """fetch the list of columns from a BigQuery table along with their data types."""
         table_ref = f"{schema}.{table}"
         table: bigquery.Table = self.bqclient.get_table(table_ref)
-        column_names = [field.name for field in table.schema]
-        return column_names
+        columns = [
+            {"name": field.name, "data_type": field.field_type}
+            for field in table.schema
+        ]
+        return columns
 
     def get_table_data(
         self,

--- a/dbt_automation/utils/postgres.py
+++ b/dbt_automation/utils/postgres.py
@@ -101,7 +101,7 @@ class PostgresClient(WarehouseInterface):
         # select
         query = f"""
         SELECT * 
-        FROM {schema}.{table}
+        FROM "{schema}"."{table}"
         """
 
         # order

--- a/dbt_automation/utils/postgres.py
+++ b/dbt_automation/utils/postgres.py
@@ -125,12 +125,12 @@ class PostgresClient(WarehouseInterface):
         """returns the column names of the specified table in the given schema"""
         resultset = self.execute(
             f"""
-            SELECT column_name 
+            SELECT column_name, data_type
             FROM information_schema.columns
             WHERE table_schema = '{schema}' AND table_name = '{table}';
             """
         )
-        return [x[0] for x in resultset]
+        return [{"name": x[0], "data_type": x[1]} for x in resultset]
 
     def get_columnspec(self, schema: str, table: str):
         """get the column schema for this table"""

--- a/tests/warehouse/test_bigquery_ops.py
+++ b/tests/warehouse/test_bigquery_ops.py
@@ -198,12 +198,7 @@ class TestBigqueryOperations:
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "columns": [
-                {
-                    "columnname": "NGO",
-                },
-                {
-                    "columnname": "SPOC",
-                },
+                "NGO", "SPOC"
             ],
             "source_columns": ["NGO", "Month", "measure1", "measure2", "Indicator"],
             "output_column_name": "coalesce",
@@ -248,15 +243,15 @@ class TestBigqueryOperations:
             "columns": [
                 {
                     "name": "NGO",
-                    "is_col": "yes",
+                    "is_col": True,
                 },
                 {
                     "name": "SPOC",
-                    "is_col": "yes",
+                    "is_col": True,
                 },
                 {
                     "name": "test",
-                    "is_col": "no",
+                    "is_col": False,
                 },
             ],
             "source_columns": ["NGO", "SPOC", "measure1", "measure2", "Indicator"],

--- a/tests/warehouse/test_bigquery_ops.py
+++ b/tests/warehouse/test_bigquery_ops.py
@@ -197,9 +197,7 @@ class TestBigqueryOperations:
             },
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
-            "columns": [
-                "NGO", "SPOC"
-            ],
+            "columns": ["NGO", "SPOC"],
             "source_columns": ["NGO", "Month", "measure1", "measure2", "Indicator"],
             "output_column_name": "coalesce",
         }
@@ -662,12 +660,8 @@ class TestBigqueryOperations:
                         "dest_schema": "pytest_intermediate",
                         "output_name": output_name,
                         "columns": [
-                            {
-                                "columnname": "NGO",
-                            },
-                            {
-                                "columnname": "Indicator",
-                            },
+                            "NGO",
+                            "Indicator",
                         ],
                         "source_columns": [
                             "NGO",
@@ -693,15 +687,15 @@ class TestBigqueryOperations:
                         "columns": [
                             {
                                 "name": "NGO",
-                                "is_col": "yes",
+                                "is_col": True,
                             },
                             {
                                 "name": "Indicator",
-                                "is_col": "yes",
+                                "is_col": True,
                             },
                             {
                                 "name": "test",
-                                "is_col": "no",
+                                "is_col": False,
                             },
                         ],
                         "source_columns": [

--- a/tests/warehouse/test_bigquery_ops.py
+++ b/tests/warehouse/test_bigquery_ops.py
@@ -150,7 +150,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "ngo" in cols
         assert "month" in cols
         assert "NGO" not in cols
@@ -181,7 +186,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "MONTH" not in cols
 
     def test_coalescecolumns(self):
@@ -210,7 +220,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "coalesce" in cols
         col_data = wc_client.get_table_data("pytest_intermediate", output_name, 5)
         col_data_original = wc_client.get_table_data(
@@ -264,7 +279,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "concat_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -305,7 +325,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "measure1" in cols
         assert "measure2" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
@@ -340,7 +365,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "add_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -375,7 +405,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "sub_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -410,7 +445,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "mul_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -445,7 +485,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "div_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -483,7 +528,12 @@ class TestBigqueryOperations:
 
         TestBigqueryOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "NGO" in cols
         table_data_org = wc_client.get_table_data(
             "pytest_intermediate", "_airbyte_raw_Sheet1", 10
@@ -742,7 +792,12 @@ class TestBigqueryOperations:
         )
 
         TestBigqueryOperations.execute_dbt("run", output_name)
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "NGO" in cols
         assert "measure1" in cols
         assert "measure2" in cols

--- a/tests/warehouse/test_postgres_ops.py
+++ b/tests/warehouse/test_postgres_ops.py
@@ -152,7 +152,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "ngo" in cols
         assert "month" in cols
         assert "NGO" not in cols
@@ -183,7 +188,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "MONTH" not in cols
 
     def test_coalescecolumns(self):
@@ -212,7 +222,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "coalesce" in cols
         col_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         col_data_original = wc_client.get_table_data(
@@ -272,7 +287,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "concat_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -313,7 +333,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "measure1" in cols
         assert "measure2" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
@@ -348,7 +373,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "add_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -383,7 +413,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "sub_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -418,7 +453,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "mul_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -453,7 +493,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "div_col" in cols
         table_data = wc_client.get_table_data("pytest_intermediate", output_name, 1)
         assert (
@@ -492,7 +537,12 @@ class TestPostgresOperations:
 
         TestPostgresOperations.execute_dbt("run", output_name)
 
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "NGO" in cols
         table_data_org = wc_client.get_table_data(
             "pytest_intermediate",
@@ -757,7 +807,12 @@ class TestPostgresOperations:
         )
 
         TestBigqueryOperations.execute_dbt("run", output_name)
-        cols = wc_client.get_table_columns("pytest_intermediate", output_name)
+        cols = [
+            col_dict["name"]
+            for col_dict in wc_client.get_table_columns(
+                "pytest_intermediate", output_name
+            )
+        ]
         assert "NGO" in cols
         assert "measure1" in cols
         assert "measure2" in cols

--- a/tests/warehouse/test_postgres_ops.py
+++ b/tests/warehouse/test_postgres_ops.py
@@ -200,9 +200,7 @@ class TestPostgresOperations:
             "dest_schema": "pytest_intermediate",
             "output_name": output_name,
             "source_columns": ["NGO", "Month", "measure1", "measure2", "Indicator"],
-            "columns": [
-                "NGO", "SPOC"
-            ],
+            "columns": ["NGO", "SPOC"],
             "output_column_name": "coalesce",
         }
 
@@ -677,12 +675,8 @@ class TestPostgresOperations:
                         "dest_schema": "pytest_intermediate",
                         "output_name": output_name,
                         "columns": [
-                            {
-                                "columnname": "NGO",
-                            },
-                            {
-                                "columnname": "Indicator",
-                            },
+                            "NGO",
+                            "Indicator",
                         ],
                         "source_columns": [
                             "NGO",
@@ -708,15 +702,15 @@ class TestPostgresOperations:
                         "columns": [
                             {
                                 "name": "NGO",
-                                "is_col": "yes",
+                                "is_col": True,
                             },
                             {
                                 "name": "Indicator",
-                                "is_col": "yes",
+                                "is_col": True,
                             },
                             {
                                 "name": "test",
-                                "is_col": "no",
+                                "is_col": False,
                             },
                         ],
                         "source_columns": [

--- a/tests/warehouse/test_postgres_ops.py
+++ b/tests/warehouse/test_postgres_ops.py
@@ -201,12 +201,7 @@ class TestPostgresOperations:
             "output_name": output_name,
             "source_columns": ["NGO", "Month", "measure1", "measure2", "Indicator"],
             "columns": [
-                {
-                    "columnname": "NGO",
-                },
-                {
-                    "columnname": "SPOC",
-                },
+                "NGO", "SPOC"
             ],
             "output_column_name": "coalesce",
         }
@@ -257,15 +252,15 @@ class TestPostgresOperations:
             "columns": [
                 {
                     "name": "NGO",
-                    "is_col": "yes",
+                    "is_col": True,
                 },
                 {
                     "name": "SPOC",
-                    "is_col": "yes",
+                    "is_col": True,
                 },
                 {
                     "name": "test",
-                    "is_col": "no",
+                    "is_col": False,
                 },
             ],
             "output_column_name": "concat_col",


### PR DESCRIPTION
- [x] add support for data type for postgres
- [x] add support for data type for bigquery
- [x] Merge operations cte fixes; the operation doesn't output the correct cte. 
- [x] update the merge operation to take input either as a source or a model. Currently it assumes the input to be a source.
- [x]  `_sql` function of each operation needs to return the output columns also now. Update merge_operation accordingly.